### PR TITLE
chore: update prod-test to use actual snapshot1 role

### DIFF
--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -22,7 +22,7 @@ const env: Partial<typeof commonEnv> = {
   currencyName: 'EWT',
   currencySymbol: 'EWT',
   blockExlorerUrl: 'https://explorer.energyweb.org',
-  snapshotRoles: ['testsnapshot1test.roles.snapshottest.apps.energyweb.auth.ewc']
+  snapshotRoles: ['snapshot1.roles.consortiapool.apps.energyweb.auth.ewc']
 };
 
 export const environment = { ...commonEnv, ...env };


### PR DESCRIPTION
PR to update role used by the prod-test UI. This is so that we can test using the actual snapshot1 file before we release the public UI